### PR TITLE
Fix: CommaTimings now include the predicted next timing

### DIFF
--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -880,8 +880,11 @@ namespace MajSimai
                         noteContentBuffer[noteContentBufIndex++] = curChar;
                     }
                 }
-                var noteTimingPoints = new SimaiTimingPoint[noteRawTimingBufIndex];
 
+                BufferHelper.EnsureBufferLength(commaTimingBufIndex + 1, ref commaTimingBuffer);
+                commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, fumen.Length);
+                
+                var noteTimingPoints = new SimaiTimingPoint[noteRawTimingBufIndex];
                 Parallel.For(0, noteRawTimingBufIndex, i =>
                 {
                     var rawTiming = noteRawTimingBuffer[i];

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -991,7 +991,7 @@ namespace MajSimai
                       .AppendLine(chart.Level);
                 }
             }
-            sb.Append("&des_")
+            sb.Append("&des")
               .Append('=')
               .AppendLine(finalDesigner);
             foreach (var command in simaiFile.Commands)
@@ -1012,9 +1012,12 @@ namespace MajSimai
                   .Append(i + 1)
                   .Append('=')
                   .Append(chart)
-                  .AppendLine()
-                  .Append('E')
                   .AppendLine();
+                if (!chart.EndsWith('E'))
+                {
+                    sb.Append('E')
+                      .AppendLine();
+                }
             }
             return sb.ToString();
         }


### PR DESCRIPTION
CommaTimings包含下一个预测的Timing，如`(60){4},`会包含两个`{4}`的Timing，`(60){4},{1},`会包含一个`{4}`和两个`{1}`的Timing，这样可以让Edit找到下一个将会放置note的timing，在开启了follow cursor的Edit-Neo上应该很有用（

这是一段写的很丑的寻找CaretIndex所对应的Time的参考
```
var time = timings.FirstOrDefault(n =>
    n.RawTextPosition <= GetRawFumenPosition() &&
    n.RawTextPosition + n.RawContent.Length >= GetRawFumenPosition()
)?.Timing ?? 
(timings.Count > 0 ? SimaiProcess.timingLists[selectedDifficulty]?.Last().Timing : 0d) ??
0d;
```