### PR TITLE
MajSimai for MajdataEdit-Neo

### DIFF
--- a/Runtime/SimaiChart.cs
+++ b/Runtime/SimaiChart.cs
@@ -8,20 +8,14 @@ namespace MajSimai
 {
     public class SimaiChart
     {
-        public string Level { get; }
-        public string Designer { get; }
+        public string Level { get; set; }
+        public string Designer { get; set; }
+        public string Fumen { get; set; }
         public bool IsEmpty
         {
             get
             {
                 return _isEmpty;
-            }
-        }
-        public string Fumen
-        {
-            get
-            {
-                return _fumen;
             }
         }
         public ReadOnlySpan<SimaiTimingPoint> NoteTimings
@@ -40,9 +34,7 @@ namespace MajSimai
         }
         public readonly static SimaiChart Empty = new SimaiChart();
 
-
         readonly bool _isEmpty;
-        readonly string _fumen;
         readonly SimaiTimingPoint[] _noteTimings;
         readonly SimaiTimingPoint[] _commaTimings;
         public SimaiChart(string level, string designer, string fumen,
@@ -109,14 +101,14 @@ namespace MajSimai
             {
                 ArrayPool<SimaiTimingPoint>.Shared.Return(buffer);
             }
-            _fumen = fumen;
+            Fumen = fumen;
             _isEmpty = _noteTimings.Length == 0;
         }
         SimaiChart()
         {
             Level = string.Empty;
             Designer = string.Empty;
-            _fumen = string.Empty;
+            Fumen = string.Empty;
             _noteTimings = Array.Empty<SimaiTimingPoint>();
             _commaTimings = Array.Empty<SimaiTimingPoint>();
             _isEmpty = true;

--- a/Runtime/SimaiChart.cs
+++ b/Runtime/SimaiChart.cs
@@ -8,14 +8,20 @@ namespace MajSimai
 {
     public class SimaiChart
     {
-        public string Level { get; set; }
-        public string Designer { get; set; }
-        public string Fumen { get; set; }
+        public string Level { get; }
+        public string Designer { get; }
         public bool IsEmpty
         {
             get
             {
                 return _isEmpty;
+            }
+        }
+        public string Fumen
+        {
+            get
+            {
+                return _fumen;
             }
         }
         public ReadOnlySpan<SimaiTimingPoint> NoteTimings
@@ -34,7 +40,9 @@ namespace MajSimai
         }
         public readonly static SimaiChart Empty = new SimaiChart();
 
+
         readonly bool _isEmpty;
+        readonly string _fumen;
         readonly SimaiTimingPoint[] _noteTimings;
         readonly SimaiTimingPoint[] _commaTimings;
         public SimaiChart(string level, string designer, string fumen,
@@ -101,14 +109,14 @@ namespace MajSimai
             {
                 ArrayPool<SimaiTimingPoint>.Shared.Return(buffer);
             }
-            Fumen = fumen;
+            _fumen = fumen;
             _isEmpty = _noteTimings.Length == 0;
         }
         SimaiChart()
         {
             Level = string.Empty;
             Designer = string.Empty;
-            Fumen = string.Empty;
+            _fumen = string.Empty;
             _noteTimings = Array.Empty<SimaiTimingPoint>();
             _commaTimings = Array.Empty<SimaiTimingPoint>();
             _isEmpty = true;

--- a/Runtime/SimaiFile.cs
+++ b/Runtime/SimaiFile.cs
@@ -11,6 +11,7 @@ namespace MajSimai
     {
         public string Title { get; set; }
         public string Artist { get; set; }
+        public string FinalDesigner { get; set; }
         public float Offset { get; set; }
         public SimaiChart[] Charts
         {
@@ -33,12 +34,14 @@ namespace MajSimai
 
         public SimaiFile(string title, 
                          string artist, 
+                         string finalDesigner, 
                          float offset,
                          string hash,
                          IEnumerable<SimaiChart>? levels, IEnumerable<SimaiCommand>? commands)
         {
             Title = title ?? string.Empty;
             Artist = artist ?? string.Empty;
+            FinalDesigner = finalDesigner ?? string.Empty;
             Offset = offset;
             Hash = hash ?? string.Empty;
 
@@ -78,13 +81,14 @@ namespace MajSimai
                 string.Empty
             };
 
-            return new SimaiFile(title, artist, 0, string.Empty, emptyCharts, Array.Empty<SimaiCommand>());
+            return new SimaiFile(title, artist, string.Empty, 0, string.Empty, emptyCharts, Array.Empty<SimaiCommand>());
         }
 #if NET7_0_OR_GREATER
         internal unsafe MajSimai.Unmanaged.UnmanagedSimaiFile ToUnmanaged()
         {
             var titlePtr = (char*)null;
             var artistPtr = (char*)null;
+            var finalDesignerPtr = (char*)null;
             var chartArray = (MajSimai.Unmanaged.UnmanagedSimaiChart*)Marshal.AllocHGlobal(sizeof(MajSimai.Unmanaged.UnmanagedSimaiChart) * 7);
             var commandArray = (MajSimai.Unmanaged.UnmanagedSimaiCommand*)null;
 
@@ -95,6 +99,10 @@ namespace MajSimai
             if (!string.IsNullOrEmpty(Artist))
             {
                 artistPtr = (char*)Marshal.StringToHGlobalAnsi(Artist);
+            }
+            if (!string.IsNullOrEmpty(FinalDesigner))
+            {
+                finalDesignerPtr = (char*)Marshal.StringToHGlobalAnsi(FinalDesigner);
             }
             for (var i = 0; i < 7; i++)
             {
@@ -116,6 +124,9 @@ namespace MajSimai
 
                 artist = artistPtr,
                 artistLen = Artist.Length,
+
+                finalDesigner = finalDesignerPtr,
+                finalDesignerLen = FinalDesigner.Length,
 
                 offset = Offset,
 

--- a/Runtime/SimaiFile.cs
+++ b/Runtime/SimaiFile.cs
@@ -34,10 +34,11 @@ namespace MajSimai
 
         public SimaiFile(string title, 
                          string artist, 
-                         string finalDesigner, 
                          float offset,
                          string hash,
-                         IEnumerable<SimaiChart>? levels, IEnumerable<SimaiCommand>? commands)
+                         IEnumerable<SimaiChart>? levels, 
+                         IEnumerable<SimaiCommand>? commands,
+                         string finalDesigner = "")
         {
             Title = title ?? string.Empty;
             Artist = artist ?? string.Empty;
@@ -81,7 +82,7 @@ namespace MajSimai
                 string.Empty
             };
 
-            return new SimaiFile(title, artist, string.Empty, 0, string.Empty, emptyCharts, Array.Empty<SimaiCommand>());
+            return new SimaiFile(title, artist, 0, string.Empty, emptyCharts, Array.Empty<SimaiCommand>());
         }
 #if NET7_0_OR_GREATER
         internal unsafe MajSimai.Unmanaged.UnmanagedSimaiFile ToUnmanaged()

--- a/Runtime/SimaiMetadata.cs
+++ b/Runtime/SimaiMetadata.cs
@@ -11,6 +11,7 @@ namespace MajSimai
     {
         public string Title { get; }
         public string Artist { get; }
+        public string FinalDesigner { get; }
         public float Offset { get; }
         public ReadOnlySpan<string> Designers
         {
@@ -51,7 +52,7 @@ namespace MajSimai
         readonly string[] _fumens;
         readonly SimaiCommand[] _commands;
 
-        public SimaiMetadata(string title, string artist, float offset, 
+        public SimaiMetadata(string title, string artist, string finalDesigner, float offset, 
                              IEnumerable<string>? designers,
                              IEnumerable<string>? levels,
                              IEnumerable<string>? fumens,
@@ -68,6 +69,7 @@ namespace MajSimai
             }
             Title = title;
             Artist = artist;
+            FinalDesigner = finalDesigner;
             Offset = offset;
             _designers = new string[7];
             _levels = new string[7];
@@ -123,7 +125,7 @@ namespace MajSimai
                 ArrayPool<SimaiCommand>.Shared.Return(buffer);
             }
         }
-        public SimaiMetadata(string title, string artist, float offset,
+        public SimaiMetadata(string title, string artist, string finalDesigner, float offset, 
                              ReadOnlySpan<string> designers,
                              ReadOnlySpan<string> levels,
                              ReadOnlySpan<string> fumens,
@@ -140,6 +142,7 @@ namespace MajSimai
             }
             Title = title;
             Artist = artist;
+            FinalDesigner = finalDesigner;
             Offset = offset;
             _designers = new string[7];
             _levels = new string[7];

--- a/Runtime/SimaiMetadata.cs
+++ b/Runtime/SimaiMetadata.cs
@@ -52,12 +52,13 @@ namespace MajSimai
         readonly string[] _fumens;
         readonly SimaiCommand[] _commands;
 
-        public SimaiMetadata(string title, string artist, string finalDesigner, float offset, 
+        public SimaiMetadata(string title, string artist, float offset, 
                              IEnumerable<string>? designers,
                              IEnumerable<string>? levels,
                              IEnumerable<string>? fumens,
                              IEnumerable<SimaiCommand>? commands,
-                             string hash)
+                             string hash,
+                             string finalDesigner = "")
         {
             if(hash is null)
             {
@@ -125,12 +126,13 @@ namespace MajSimai
                 ArrayPool<SimaiCommand>.Shared.Return(buffer);
             }
         }
-        public SimaiMetadata(string title, string artist, string finalDesigner, float offset, 
+        public SimaiMetadata(string title, string artist, float offset, 
                              ReadOnlySpan<string> designers,
                              ReadOnlySpan<string> levels,
                              ReadOnlySpan<string> fumens,
                              ReadOnlySpan<SimaiCommand> commands,
-                             string hash)
+                             string hash,
+                             string finalDesigner = "")
         {
             if (hash is null)
             {

--- a/Runtime/SimaiNote.cs
+++ b/Runtime/SimaiNote.cs
@@ -17,6 +17,7 @@ namespace MajSimai
         public bool IsSlideNoHead { get; set; }
         public bool IsMine { get; set; } //炸弹音符
         public bool IsMineSlide { get; set; }
+        public bool UsingSV { get; set; }
 
         public string RawContent { get; set; } //used for star explain
 
@@ -49,6 +50,7 @@ namespace MajSimai
                 isEx = IsEx,
                 isMine = IsMine,
                 isMineSlide = IsMineSlide,
+                usingSV = UsingSV,
                 isSlideNoHead = IsSlideNoHead,
                 touchArea = TouchArea,
 

--- a/Runtime/SimaiNoteParser.cs
+++ b/Runtime/SimaiNoteParser.cs
@@ -277,6 +277,9 @@ namespace MajSimai
             simaiNote.IsMine = detectResult.IsMine;
             simaiNote.IsMineSlide = detectResult.IsMineSlide;
 
+            //UsingSV
+            simaiNote.UsingSV = detectResult.UsingSV;
+
             simaiNote.RawContent = new string(noteTextCopy.Trim());
             outSimaiNote = simaiNote;
             return true;
@@ -565,6 +568,7 @@ namespace MajSimai
                 public readonly bool IsFakeRotate;          // $$
                 public readonly bool IsMine;                // m
                 public readonly bool IsMineSlide;           // m
+                public readonly bool UsingSV;               // c
 
                 public readonly Span<char> NoteContent;
 
@@ -581,6 +585,7 @@ namespace MajSimai
                                 bool isFakeRotate,
                                 bool isMine,
                                 bool isMineSlide,
+                                bool usingSV,
                                 Span<char> noteContent)
                 {
                     IsTouchNote = isTouchNote;
@@ -597,6 +602,7 @@ namespace MajSimai
                     IsMine = isMine;
                     IsMineSlide = isMineSlide;
                     NoteContent = noteContent;
+                    UsingSV = usingSV;
                 }
 
                 public static NoteFlag Detect(zString noteContent, Span<char> dst)
@@ -619,6 +625,7 @@ namespace MajSimai
                     var isFakeRotate = false;
                     var isMine = false;
                     var isMineSlide = false;
+                    var usingSV = true;
 
                     var forceStarTagCount = 0;
                     var j = 0;
@@ -652,6 +659,9 @@ namespace MajSimai
                                 break;
                             case 'x':
                                 isEx = true;
+                                continue;
+                            case 'c':
+                                usingSV = false;
                                 continue;
                             case 'h':
                                 isHold = true;
@@ -731,6 +741,7 @@ namespace MajSimai
                                         isFakeRotate,
                                         isMine,
                                         isMineSlide,
+                                        usingSV,
                                         dst.Slice(0, j));
                 }
             }

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -53,7 +53,7 @@ namespace MajSimai
                         Console.WriteLine(ex);
                     }
                 });
-                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.Offset, metadata.Hash, rentedArrayForCharts, null);
+                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.FinalDesigner, metadata.Offset, metadata.Hash, rentedArrayForCharts, null);
                 var cmds = simaiFile.Commands;
                 var cmdCount = metadata.Commands.Length;
                 for (var i = 0; i < cmdCount; i++)
@@ -167,7 +167,7 @@ namespace MajSimai
                     }
                 }
 
-                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.Offset, metadata.Hash, rentedArrayForCharts, null);
+                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.FinalDesigner, metadata.Offset, metadata.Hash, rentedArrayForCharts, null);
                 var cmds = simaiFile.Commands;
                 var cmdCount = metadata.Commands.Length;
                 for (var i = 0; i < cmdCount; i++)
@@ -234,7 +234,7 @@ namespace MajSimai
             }
             var title = string.Empty;
             var artist = string.Empty;
-            var designer = string.Empty;
+            var finalDesigner = string.Empty;
             var first = 0f;
             var rentedArrayForDesigners = ArrayPool<string>.Shared.Rent(7);
             var rentedArrayForFumens = ArrayPool<string>.Shared.Rent(7);
@@ -286,7 +286,7 @@ namespace MajSimai
                             SetValue(valueStr, ref artist);
                             break;
                         case "des":
-                            SetValue(valueStr, ref designer);
+                            SetValue(valueStr, ref finalDesigner);
                             break;
                         case "des_1":
                             SetValue(valueStr, ref designers[0]);
@@ -421,14 +421,14 @@ namespace MajSimai
                             break;
                     }
                 }
-                if (!string.IsNullOrEmpty(designer))
+                if (!string.IsNullOrEmpty(finalDesigner))
                 {
                     for (var j = 0; j < 7; j++)
                     {
                         ref var d = ref designers[j];
                         if (string.IsNullOrEmpty(d))
                         {
-                            d = designer;
+                            d = finalDesigner;
                         }
                     }
                 }
@@ -438,6 +438,7 @@ namespace MajSimai
                 encoding.GetBytes(content, bytes);
                 return new SimaiMetadata(title,
                                          artist,
+                                         finalDesigner,
                                          first,
                                          designers,
                                          levels,
@@ -972,6 +973,8 @@ namespace MajSimai
               .AppendLine(simaiFile.Title)
               .Append($"&artist=")
               .AppendLine(simaiFile.Artist)
+              .Append($"&des=")
+              .AppendLine(simaiFile.FinalDesigner)
               .Append("&first=")
               .Append(simaiFile.Offset)
               .AppendLine();
@@ -998,9 +1001,6 @@ namespace MajSimai
                       .AppendLine(chart.Level);
                 }
             }
-            sb.Append("&des")
-              .Append('=')
-              .AppendLine(finalDesigner);
             foreach (var command in simaiFile.Commands)
             {
                 sb.Append('&')

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -842,7 +842,8 @@ namespace MajSimai
                                                                             Xcount,
                                                                             Ycount,
                                                                             bpm,
-                                                                            curHSpeed);
+                                                                            curHSpeed,
+                                                                            i);
                                         BufferHelper.EnsureBufferLength(noteRawTimingBufIndex + 1, ref noteRawTimingBuffer);
                                         noteRawTimingBuffer[noteRawTimingBufIndex++] = rawTp;
                                         fakeTime += timeInterval;
@@ -860,7 +861,8 @@ namespace MajSimai
                                                                     Xcount,
                                                                     Ycount,
                                                                     bpm,
-                                                                    curHSpeed);
+                                                                    curHSpeed,
+                                                                    i);
                                 BufferHelper.EnsureBufferLength(noteRawTimingBufIndex + 1, ref noteRawTimingBuffer);
                                 noteRawTimingBuffer[noteRawTimingBufIndex++] = rawTp;
                             }

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -382,31 +382,31 @@ namespace MajSimai
                                         var isEOF = false;
                                         range = ranges[i];
                                         maidataTxt = content[range].Trim();
-                                        if (maidataTxt.IsEmpty)
+                                        if (!maidataTxt.IsEmpty)
                                         {
-                                            continue;
-                                        }
-                                        else if (maidataTxt[0] == '&')
-                                        {
-                                            isEOF = true;
-                                            i--;
-                                            break;
-                                        }
-                                        for (var i2 = 0; i2 < maidataTxt.Length; i2++)
-                                        {
-                                            ref readonly var current = ref maidataTxt[i2];
-                                            //if (current == 'E')
+                                            if (maidataTxt[0] == '&')
+                                            {
+                                                isEOF = true;
+                                                i--;
+                                                break;
+                                            }
+                                            for (var i2 = 0; i2 < maidataTxt.Length; i2++)
+                                            {
+                                                ref readonly var current = ref maidataTxt[i2];
+                                                //if (current == 'E')
+                                                //{
+                                                //    isEOF = true;
+                                                //    break;
+                                                //}
+                                                BufferHelper.EnsureBufferLength(bufferIndex + 1, ref buffer);
+                                                buffer[bufferIndex++] = current;
+                                            }
+                                            //if (isEOF)
                                             //{
-                                            //    isEOF = true;
                                             //    break;
                                             //}
-                                            BufferHelper.EnsureBufferLength(bufferIndex + 1, ref buffer);
-                                            buffer[bufferIndex++] = current;
                                         }
-                                        //if (isEOF)
-                                        //{
-                                        //    break;
-                                        //}
+
                                         BufferHelper.EnsureBufferLength(bufferIndex + 1, ref buffer);
                                         buffer[bufferIndex++] = '\n';
                                     }

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -421,17 +421,17 @@ namespace MajSimai
                             break;
                     }
                 }
-                if (!string.IsNullOrEmpty(finalDesigner))
-                {
-                    for (var j = 0; j < 7; j++)
-                    {
-                        ref var d = ref designers[j];
-                        if (string.IsNullOrEmpty(d))
-                        {
-                            d = finalDesigner;
-                        }
-                    }
-                }
+                //if (!string.IsNullOrEmpty(designer))
+                //{
+                //    for (var j = 0; j < 7; j++)
+                //    {
+                //        ref var d = ref designers[j];
+                //        if (string.IsNullOrEmpty(d))
+                //        {
+                //            d = designer;
+                //        }
+                //    }
+                //}
                 var encoding = Encoding.UTF8;
                 var byteCount = encoding.GetByteCount(content);
                 var bytes = new byte[byteCount];

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -1020,11 +1020,11 @@ namespace MajSimai
                   .Append('=')
                   .Append(chart)
                   .AppendLine();
-                if (!chart.EndsWith('E'))
-                {
-                    sb.Append('E')
-                      .AppendLine();
-                }
+                //if (!chart.EndsWith('E'))
+                //{
+                //    sb.Append('E')
+                //      .AppendLine();
+                //}
             }
             return sb.ToString();
         }

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -585,6 +585,7 @@ namespace MajSimai
 
             float bpm = 0;
             var curHSpeed = 1f;
+            var curSVeloc = 1f;
             double time = 0; //in seconds
             var beats = 4f; //{4}
             var haveNote = false;
@@ -734,7 +735,7 @@ namespace MajSimai
                                 //Console.WriteLine("BEAT" + beats);
                             }
                             continue;
-                        case '<':// Get HS: <HS*1.0>
+                        case '<':// Get HS: <HS*1.0> / Get SV: <SV*0.5>
                             {
                                 if (haveNote)
                                 {
@@ -779,21 +780,31 @@ namespace MajSimai
                                             buffer[bufferIndex++] = currentChar;
                                             Xcount++;
                                         }
-                                        var hsContent = buffer.AsSpan(0, bufferIndex);
-                                        var isInvalid = hsContent.IsEmpty ||
-                                                        hsContent.Length < 4 ||
-                                                        hsContent[0] != 'H' ||
-                                                        hsContent[1] != 'S' ||
+                                        var Content = buffer.AsSpan(0, bufferIndex);
+                                        var isInvalid = Content.IsEmpty ||
+                                                        Content.Length < 4 ||
                                                         tagIndex == -1;
-                                        if (isInvalid) // min: HS*1
+                                        if (!isInvalid) // min: HS*1
                                         {
-                                            throw new InvalidSimaiSyntaxException(Ycount, Xcount, hsContent.ToString(), "Unexpected HS declaration syntax");
+                                            var Value = Content[(tagIndex + 1)..]; // get "1.0" from HS*1.0
+                                            if (Content[0..tagIndex].SequenceEqual("HS"))
+                                            {
+                                                if (!float.TryParse(Value, out curHSpeed))
+                                                {
+                                                    throw new InvalidSimaiMarkupException(Ycount, Xcount, Content.ToString(), "HSpeed value must be a number");
+                                                }
+                                            }
+                                            else if (Content[0..tagIndex].SequenceEqual("SV"))
+                                            {
+                                                if (!float.TryParse(Value, out curSVeloc))
+                                                {
+                                                    throw new InvalidSimaiMarkupException(Ycount, Xcount, Content.ToString(), "SVeloc value must be a number");
+                                                }
+                                            }
+                                            else throw new InvalidSimaiSyntaxException(Ycount, Xcount, Content.ToString(), $"Unexpected HS / SV declaration syntax \"{Content[0..tagIndex].ToString()}\", is it \"HS\" or \"SV\"?");
                                         }
-                                        var hsValue = hsContent[(tagIndex + 1)..]; // get "1.0" from HS*1.0
-                                        if (!float.TryParse(hsValue, out curHSpeed))
-                                        {
-                                            throw new InvalidSimaiMarkupException(Ycount, Xcount, hsContent.ToString(), "HSpeed value must be a number");
-                                        }
+                                        else throw new InvalidSimaiSyntaxException(Ycount, Xcount, Content.ToString(), "Unexpected HS / SV declaration syntax");
+
                                         //Console.WriteLine("HS" + curHSpeed);
                                     }
                                     finally
@@ -844,6 +855,7 @@ namespace MajSimai
                                                                             Ycount,
                                                                             bpm,
                                                                             curHSpeed,
+                                                                            curSVeloc,
                                                                             i);
                                         BufferHelper.EnsureBufferLength(noteRawTimingBufIndex + 1, ref noteRawTimingBuffer);
                                         noteRawTimingBuffer[noteRawTimingBufIndex++] = rawTp;
@@ -863,6 +875,7 @@ namespace MajSimai
                                                                     Ycount,
                                                                     bpm,
                                                                     curHSpeed,
+                                                                    curSVeloc,
                                                                     i);
                                 BufferHelper.EnsureBufferLength(noteRawTimingBufIndex + 1, ref noteRawTimingBuffer);
                                 noteRawTimingBuffer[noteRawTimingBufIndex++] = rawTp;
@@ -873,7 +886,7 @@ namespace MajSimai
                             noteContentBufIndex = 0;
                         }
                         BufferHelper.EnsureBufferLength(commaTimingBufIndex + 1, ref commaTimingBuffer);
-                        commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, i);
+                        commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, curSVeloc, i);
 
                         time += 1d / (bpm / 60d) * 4d / beats;
                         //Console.WriteLine(time);

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -53,7 +53,7 @@ namespace MajSimai
                         Console.WriteLine(ex);
                     }
                 });
-                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.FinalDesigner, metadata.Offset, metadata.Hash, rentedArrayForCharts, null);
+                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.Offset, metadata.Hash, rentedArrayForCharts, null, metadata.FinalDesigner);
                 var cmds = simaiFile.Commands;
                 var cmdCount = metadata.Commands.Length;
                 for (var i = 0; i < cmdCount; i++)
@@ -167,7 +167,7 @@ namespace MajSimai
                     }
                 }
 
-                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.FinalDesigner, metadata.Offset, metadata.Hash, rentedArrayForCharts, null);
+                var simaiFile = new SimaiFile(metadata.Title, metadata.Artist, metadata.Offset, metadata.Hash, rentedArrayForCharts, null, metadata.FinalDesigner);
                 var cmds = simaiFile.Commands;
                 var cmdCount = metadata.Commands.Length;
                 for (var i = 0; i < cmdCount; i++)
@@ -438,13 +438,13 @@ namespace MajSimai
                 encoding.GetBytes(content, bytes);
                 return new SimaiMetadata(title,
                                          artist,
-                                         finalDesigner,
                                          first,
                                          designers,
                                          levels,
                                          fumens,
                                          commands.AsSpan(0, cI),
-                                         hash);
+                                         hash,
+                                         finalDesigner);
             }
             catch (InvalidSimaiMarkupException)
             {

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -584,6 +584,9 @@ namespace MajSimai
             var commaTimingBufIndex = 0;
 
             float bpm = 0;
+            Span<Range> signatureSplits = stackalloc Range[2];
+            int signatureNumerator = 4;
+            int signatureDenominator = 4;
             var curHSpeed = 1f;
             var curSVeloc = 1f;
             double time = 0; //in seconds
@@ -624,15 +627,49 @@ namespace MajSimai
                                 {
                                     i += 2;
                                     Xcount += 2;
-                                    for (; i < fumen.Length; i++)
+
+                                    if (fumen[i] == 's')
                                     {
-                                        if (fumen[i] == '\n')
-                                        {
-                                            Ycount++;
-                                            Xcount = 0;
-                                            break;
-                                        }
+                                        var startAt = i + 1;
+                                        i++;
                                         Xcount++;
+                                        for (; i < fumen.Length; i++)
+                                        {
+                                            if (fumen[i] == '\n')
+                                            {
+                                                Ycount++;
+                                                Xcount = 0;
+                                                break;
+                                            }
+                                            Xcount++;
+                                        }
+                                        var endAt = i;
+                                        var signatureStr = fumen[startAt..endAt].Trim();
+
+                                        if (signatureStr.Split(signatureSplits, '/') >= 2)
+                                        {
+                                            if (!int.TryParse(signatureStr[signatureSplits[0]], out signatureNumerator))
+                                            {
+                                                signatureNumerator = 4;
+                                            }
+                                            if (!int.TryParse(signatureStr[signatureSplits[1]], out signatureDenominator))
+                                            {
+                                                signatureDenominator = 4;
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        for (; i < fumen.Length; i++)
+                                        {
+                                            if (fumen[i] == '\n')
+                                            {
+                                                Ycount++;
+                                                Xcount = 0;
+                                                break;
+                                            }
+                                            Xcount++;
+                                        }
                                     }
                                 }
                                 else
@@ -829,7 +866,7 @@ namespace MajSimai
 
                     if (fumen[i] == ',')
                     {
-                        if (haveNote || haveSV)
+                        if (haveNote)
                         {
                             var noteContent = (ReadOnlySpan<char>)(noteContentBuffer.AsSpan(0, noteContentBufIndex));
                             var fakeEachTagCount = noteContent.Count('`');
@@ -855,7 +892,7 @@ namespace MajSimai
                                                                             Ycount,
                                                                             bpm,
                                                                             curHSpeed,
-                                                                            curSVeloc,
+                                                                            1, //ignore, using comma timings
                                                                             i);
                                         BufferHelper.EnsureBufferLength(noteRawTimingBufIndex + 1, ref noteRawTimingBuffer);
                                         noteRawTimingBuffer[noteRawTimingBufIndex++] = rawTp;
@@ -875,7 +912,7 @@ namespace MajSimai
                                                                     Ycount,
                                                                     bpm,
                                                                     curHSpeed,
-                                                                    curSVeloc,
+                                                                    1,
                                                                     i);
                                 BufferHelper.EnsureBufferLength(noteRawTimingBufIndex + 1, ref noteRawTimingBuffer);
                                 noteRawTimingBuffer[noteRawTimingBufIndex++] = rawTp;
@@ -886,7 +923,7 @@ namespace MajSimai
                             noteContentBufIndex = 0;
                         }
                         BufferHelper.EnsureBufferLength(commaTimingBufIndex + 1, ref commaTimingBuffer);
-                        commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, curSVeloc, i);
+                        commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, curSVeloc, i, signatureNumerator, signatureDenominator);
 
                         time += 1d / (bpm / 60d) * 4d / beats;
                         //Console.WriteLine(time);
@@ -902,7 +939,7 @@ namespace MajSimai
                 }
 
                 BufferHelper.EnsureBufferLength(commaTimingBufIndex + 1, ref commaTimingBuffer);
-                commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, fumen.Length);
+                commaTimingBuffer[commaTimingBufIndex++] = new SimaiTimingPoint(time, null, string.Empty, Xcount, Ycount, bpm, 1, curSVeloc, fumen.Length, signatureNumerator, signatureDenominator);
                 
                 var noteTimingPoints = new SimaiTimingPoint[noteRawTimingBufIndex];
                 Parallel.For(0, noteRawTimingBufIndex, i =>

--- a/Runtime/SimaiParser.cs
+++ b/Runtime/SimaiParser.cs
@@ -589,6 +589,7 @@ namespace MajSimai
             double time = 0; //in seconds
             var beats = 4f; //{4}
             var haveNote = false;
+            var haveSV = false;
             //var noteTemp = "";
 
             int Ycount = 1, Xcount = 0;
@@ -796,10 +797,9 @@ namespace MajSimai
                                             }
                                             else if (Content[0..tagIndex].SequenceEqual("SV"))
                                             {
-                                                if (!float.TryParse(Value, out curSVeloc))
-                                                {
-                                                    throw new InvalidSimaiMarkupException(Ycount, Xcount, Content.ToString(), "SVeloc value must be a number");
-                                                }
+                                                if (float.TryParse(Value, out curSVeloc))
+                                                    haveSV = true;
+                                                else throw new InvalidSimaiMarkupException(Ycount, Xcount, Content.ToString(), "SVeloc value must be a number");
                                             }
                                             else throw new InvalidSimaiSyntaxException(Ycount, Xcount, Content.ToString(), $"Unexpected HS / SV declaration syntax \"{Content[0..tagIndex].ToString()}\", is it \"HS\" or \"SV\"?");
                                         }
@@ -829,7 +829,7 @@ namespace MajSimai
 
                     if (fumen[i] == ',')
                     {
-                        if (haveNote)
+                        if (haveNote || haveSV)
                         {
                             var noteContent = (ReadOnlySpan<char>)(noteContentBuffer.AsSpan(0, noteContentBufIndex));
                             var fakeEachTagCount = noteContent.Count('`');

--- a/Runtime/SimaiRawTimingPoint.cs
+++ b/Runtime/SimaiRawTimingPoint.cs
@@ -14,13 +14,15 @@ namespace MajSimai
         public string RawContent { get; }
         public int RawTextPositionX { get; }
         public int RawTextPositionY { get; }
+        public int RawTextPosition { get; }
 
         public SimaiRawTimingPoint(double timing, ReadOnlySpan<char> rawContent, int textPosX = 0, int textPosY = 0, float bpm = 0f,
-            float hspeed = 1f)
+            float hspeed = 1f, int textPos = 0)
         {
             Timing = timing;
             RawTextPositionX = textPosX;
             RawTextPositionY = textPosY;
+            RawTextPosition = textPos;
             if (!rawContent.IsEmpty)
             {
                 Span<char> rCSpan = stackalloc char[rawContent.Length];
@@ -59,7 +61,7 @@ namespace MajSimai
         {
             var notes = SimaiNoteParser.GetNotes(Timing, Bpm, RawContent);
 
-            return new SimaiTimingPoint(Timing, notes, RawContent, RawTextPositionX, RawTextPositionY, Bpm, HSpeed);
+            return new SimaiTimingPoint(Timing, notes, RawContent, RawTextPositionX, RawTextPositionY, Bpm, HSpeed, RawTextPosition);
         }
         public Task<SimaiTimingPoint> ParseAsync()
         {

--- a/Runtime/SimaiRawTimingPoint.cs
+++ b/Runtime/SimaiRawTimingPoint.cs
@@ -10,14 +10,15 @@ namespace MajSimai
     {
         public double Timing { get; }
         public float Bpm { get; }
-        public float HSpeed { get; } 
+        public float HSpeed { get; }
+        public float SVeloc { get; }
         public string RawContent { get; }
         public int RawTextPositionX { get; }
         public int RawTextPositionY { get; }
         public int RawTextPosition { get; }
 
         public SimaiRawTimingPoint(double timing, ReadOnlySpan<char> rawContent, int textPosX = 0, int textPosY = 0, float bpm = 0f,
-            float hspeed = 1f, int textPos = 0)
+            float hspeed = 1f, float sveloc = 1f, int textPos = 0)
         {
             Timing = timing;
             RawTextPositionX = textPosX;
@@ -56,12 +57,13 @@ namespace MajSimai
             }
             Bpm = bpm;
             HSpeed = hspeed;
+            SVeloc = sveloc;
         }
         public SimaiTimingPoint Parse()
         {
             var notes = SimaiNoteParser.GetNotes(Timing, Bpm, RawContent);
 
-            return new SimaiTimingPoint(Timing, notes, RawContent, RawTextPositionX, RawTextPositionY, Bpm, HSpeed, RawTextPosition);
+            return new SimaiTimingPoint(Timing, notes, RawContent, RawTextPositionX, RawTextPositionY, Bpm, HSpeed, SVeloc, RawTextPosition);
         }
         public Task<SimaiTimingPoint> ParseAsync()
         {

--- a/Runtime/SimaiTimingPoint.cs
+++ b/Runtime/SimaiTimingPoint.cs
@@ -10,6 +10,7 @@ namespace MajSimai
         public double Timing { get; set; } = 0;
         public float Bpm { get; set; } = -1;
         public float HSpeed { get; set; } = 1f;
+        public float SVeloc { get; set; } = 1f;
         public string RawContent { get; } = string.Empty;
         public int RawTextPositionX { get; }
         public int RawTextPositionY { get; }
@@ -18,7 +19,7 @@ namespace MajSimai
         public bool IsEmpty => Notes.Length == 0;
 
         public SimaiTimingPoint(double timing, SimaiNote[]? notes, ReadOnlySpan<char> rawContent, int textPosX = 0, int textPosY = 0, float bpm = 0f,
-            float hspeed = 1f, int rawTextPosition = 0)
+            float hspeed = 1f, float sveloc = 1f, int rawTextPosition = 0)
         {
             Timing = timing;
             RawTextPositionX = textPosX;
@@ -57,6 +58,7 @@ namespace MajSimai
             }
             Bpm = bpm;
             HSpeed = hspeed;
+            SVeloc = sveloc;
             if (notes != null)
             {
                 Notes = notes;
@@ -85,6 +87,7 @@ namespace MajSimai
                 timing = Timing,
                 bpm = Bpm,
                 hSpeed = HSpeed,
+                sVeloc = SVeloc,
                 rawTextPositionX = RawTextPositionX,
                 rawTextPositionY = RawTextPositionY,
                 rawTextPosition = RawTextPosition,

--- a/Runtime/SimaiTimingPoint.cs
+++ b/Runtime/SimaiTimingPoint.cs
@@ -15,17 +15,19 @@ namespace MajSimai
         public int RawTextPositionX { get; }
         public int RawTextPositionY { get; }
         public int RawTextPosition { get; }
+        public int SignatureNumerator { get; } = 4;
+        public int SignatureDenominator { get; } = 4;
         public SimaiNote[] Notes { get; set; } = Array.Empty<SimaiNote>();
         public bool IsEmpty => Notes.Length == 0;
 
         public SimaiTimingPoint(double timing, SimaiNote[]? notes, ReadOnlySpan<char> rawContent, int textPosX = 0, int textPosY = 0, float bpm = 0f,
-            float hspeed = 1f, float sveloc = 1f, int rawTextPosition = 0)
+            float hspeed = 1f, float sveloc = 1f, int rawTextPosition = 0, int signatureNumerator = 0, int signatureDenominator = 0)
         {
             Timing = timing;
             RawTextPositionX = textPosX;
             RawTextPositionY = textPosY;
             RawTextPosition = rawTextPosition;
-            if(!rawContent.IsEmpty)
+            if (!rawContent.IsEmpty)
             {
                 Span<char> rCSpan = stackalloc char[rawContent.Length];
                 rawContent.Replace(rCSpan, '\n', ' ');
@@ -43,7 +45,7 @@ namespace MajSimai
                     }
                 }
                 var newRaw = rCSpan.Slice(0, i2);
-                if(newRaw != rawContent)
+                if (newRaw != rawContent)
                 {
                     RawContent = new string(rCSpan.Slice(0, i2));
                 }
@@ -63,6 +65,9 @@ namespace MajSimai
             {
                 Notes = notes;
             }
+
+            SignatureNumerator = signatureNumerator;
+            SignatureDenominator = signatureDenominator;
         }
 #if NET7_0_OR_GREATER
         internal unsafe MajSimai.Unmanaged.UnmanagedSimaiTimingPoint ToUnmanaged()

--- a/Runtime/Unmanaged/UnmanagedSimaiFile.cs
+++ b/Runtime/Unmanaged/UnmanagedSimaiFile.cs
@@ -12,12 +12,14 @@ internal unsafe struct UnmanagedSimaiFile
 {
     public int titleLen;
     public int artistLen;
+    public int finalDesignerLen;
     public float offset;
     public int chartsLen;
     public int commandsLen;
 
     public char* title;
     public char* artist;
+    public char* finalDesigner;
     public UnmanagedSimaiChart* charts;
     public UnmanagedSimaiCommand* commands;
 
@@ -25,6 +27,7 @@ internal unsafe struct UnmanagedSimaiFile
     {
         Marshal.FreeHGlobal((nint)title);
         Marshal.FreeHGlobal((nint)artist);
+        Marshal.FreeHGlobal((nint)finalDesigner);
         if(charts is not null)
         {
             for (var i = 0; i < chartsLen; i++)
@@ -46,8 +49,10 @@ internal unsafe struct UnmanagedSimaiFile
 
         title = null; 
         artist = null;
+        finalDesigner = null;
         titleLen = 0;
         artistLen = 0;
+        finalDesignerLen = 0;
         chartsLen = 0;
         commandsLen = 0;
     }

--- a/Runtime/Unmanaged/UnmanagedSimaiNote.cs
+++ b/Runtime/Unmanaged/UnmanagedSimaiNote.cs
@@ -27,6 +27,7 @@ internal unsafe struct UnmanagedSimaiNote
     public bool isSlideNoHead;
     public bool isMine;
     public bool isMineSlide;
+    public bool usingSV;
     public int rawContentLen;
 
     public char* rawContent;

--- a/Runtime/Unmanaged/UnmanagedSimaiTimingPoint.cs
+++ b/Runtime/Unmanaged/UnmanagedSimaiTimingPoint.cs
@@ -14,6 +14,7 @@ internal unsafe struct UnmanagedSimaiTimingPoint
     public double timing;
     public float bpm;
     public float hSpeed;
+    public float sVeloc;
     public int rawTextPositionX;
     public int rawTextPositionY;
     public int rawTextPosition;


### PR DESCRIPTION
修改了一些（也许）无伤大雅的内容，我觉得不论是支持现有viewx还是支持未来的neo+play这些更改都是需要的（

主要内容：
- NoteTimings加入RawTextPosition传入
<br/>

- 添加了对&des=的读写支持，即FinalDesigner（构造函数里加了可选参数传参，公共api是没有变的）这样也避免了Deparse生成一堆des
- 读取时Fumen不忽略空行
- Deparse不自动添加E
> 如果这里保持单向传入解析器，那到时候edit还得另外写一个读原fumen的解析器并自托管这些数据，我觉得不值得，现在的流程是这样：读取SimaiFile -> Fumen -> SimaiFile管file metadata，edit内部托管Level, Designer, Fumen这些chart metadata -> 保存时再通过修改后的托管数据new SimaiChart传回SimaiFile -> SimaiFile Deparse
<br/>

- 添加对SV的支持：读取SV到CommaTimings，一次传参给CalcSvPos之类的函数这样
- 添加对自定义拍号注释的解析（||s3/4）这个相对不像parser干的事，但是未来也许需要出一个自定义拍号影响星星启动时间的功能，那这个就有必要了


Unmanaged部分全部没经过测试，不知道会不会有问题